### PR TITLE
Add Docker Compose file for local PostgreSQL dev database

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ You need to have the latest stable versions of [Node.js](https://nodejs.org/en) 
 
 If it is the first time you're running the app, you will have to install all of the required package dependencies by running `npm install` in the root directory.
 
+The app requires a [PostgreSQL](https://www.postgresql.org/) database to be available. The easiest way to spin up one locally is by installing [Docker](https://www.docker.com/) and then running:
+
+```bash
+docker compose up
+```
+
+in this directory.
+
 To start a local development server, use:
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  postgres:
+    image: "postgres:16.1"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: taxes_app
+      POSTGRES_PASSWORD: dev_pwd
+      POSTGRES_DB: taxes


### PR DESCRIPTION
This PR adds a `compose.yaml` file in the root directory, to help developers spin up a PostgreSQL database server for local development.