### PR TITLE
Enable `forceConsistentCasingInFileNames` option for TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
This will help avoid file name casing issues, like the ones Răzvan encountered in #17.